### PR TITLE
Account for one-off plugin naming exceptions

### DIFF
--- a/.github/workflows/coding-quality.yml
+++ b/.github/workflows/coding-quality.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    - cron: '0 0 * * *'
 
 jobs:
   code-quality:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - develop
   pull_request:
-  schedule:
-    - cron: '0 0 * * *'
 
 jobs:
   coding-standards:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Plugin Loader` will be documented in this file.
 
+## 0.1.2 - 2024-02-09
+
+- Account for some one-off plugins that don't follow the standard naming conventions.
+
 ## 0.1.1 - 2023-07-24
 
 - Added APCu caching for plugin folder lookups.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "alleyinteractive/composer-wordpress-autoloader": "^1.0"
     },
     "require-dev": {
-        "alleyinteractive/alley-coding-standards": "^1.0",
+        "alleyinteractive/alley-coding-standards": "^2.0",
         "szepeviktor/phpstan-wordpress": "^1.1"
     },
     "config": {

--- a/src/class-wp-plugin-loader.php
+++ b/src/class-wp-plugin-loader.php
@@ -146,6 +146,24 @@ class WP_Plugin_Loader {
 					$paths[] = "$folder/$sanitized_plugin/$sanitized_plugin.php";
 					$paths[] = "$folder/$sanitized_plugin/plugin.php";
 					$paths[] = "$folder/$sanitized_plugin.php";
+
+					if ( 0 === strpos( $sanitized_plugin, 'wordpress-' ) ) {
+						$paths[] = "$folder/" . substr( $sanitized_plugin, 10 ) . "/$sanitized_plugin.php";
+					} elseif ( 0 === strpos( $sanitized_plugin, 'wp-' ) ) {
+						$paths[] = "$folder/" . substr( $sanitized_plugin, 3 ) . "/$sanitized_plugin.php";
+					}
+
+					// Plugin-specific exceptions that don't follow the standard pattern.
+					$paths = array_merge(
+						$paths,
+						(array) match ( $sanitized_plugin ) {
+							'logger' => [ "$folder/logger/ai-logger.php" ],
+							'shortcake' => [ "$folder/shortcake/dev.php" ],
+							'vip-decoupled-bundle' => [ "$folder/vip-decoupled-bundle/vip-decoupled.php" ],
+							'wp-updates-notifier' => [ "$folder/wp-updates-notifier/class-sc-wp-updates-notifier.php" ],
+							default => [],
+						},
+					);
 				}
 
 				foreach ( $paths as $path ) {


### PR DESCRIPTION
Account for `wordpress-fieldmanager` having a main plugin file of `fieldmanager.php`. Also account for some other one-off plugins that don't follow the standard. Borrows work from Reflector (internal to Alley project).