### PR TITLE
Globalize new variables after loading plugin file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Plugin Loader` will be documented in this file.
 
+## 0.2.0 - 2025-02-26
+
+- Globalize variables after including the plugin file.
+
 ## 0.1.6 - 2024-12-17
 
 - When a plugin is not found, exit with a status code of 1 and send a `500`

--- a/src/class-wp-plugin-loader.php
+++ b/src/class-wp-plugin-loader.php
@@ -197,7 +197,7 @@ class WP_Plugin_Loader {
 	 * @return void
 	 */
 	protected function handle_plugin_path( string $path ): void {
-		// What follows is a copy of _wpcom_vip_include_plugin().
+		// What follows is mostly a copy of _wpcom_vip_include_plugin().
 
 		// Start by marking down the currently defined variables (so we can exclude them later).
 		$pre_include_variables = get_defined_vars();

--- a/src/class-wp-plugin-loader.php
+++ b/src/class-wp-plugin-loader.php
@@ -197,7 +197,32 @@ class WP_Plugin_Loader {
 	 * @return void
 	 */
 	protected function handle_plugin_path( string $path ): void {
+		// What follows is a copy of _wpcom_vip_include_plugin().
+
+		// Start by marking down the currently defined variables (so we can exclude them later).
+		$pre_include_variables = get_defined_vars();
+
+		// Support symlinks.
+		wp_register_plugin_realpath( $path );
+
+		// Now include.
 		require_once $path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
+
+		// Disallow some global variables.
+		$disallowed_globals = [
+			'blacklist'             => 0,
+			'pre_include_variables' => 0,
+			'new_variables'         => 0,
+			'helper_file'           => 0,
+		];
+
+		// Let's find out what's new by comparing the current variables to the previous ones.
+		$new_variables = array_diff_key( get_defined_vars(), $GLOBALS, $disallowed_globals, $pre_include_variables );
+
+		// Globalize each new variable.
+		foreach ( $new_variables as $new_variable => $value ) {
+			$GLOBALS[ $new_variable ] = $value; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+		}
 
 		// Mark the plugin as loaded if it is in the /plugins directory.
 		if ( 0 === strpos( $path, WP_PLUGIN_DIR ) ) {


### PR DESCRIPTION
Fixes #16. As noted there, this approach was previously implemented at https://l.alley.dev/c0cc8fb23c, which is derived from https://github.com/Automattic/vip-go-mu-plugins/blob/60780fee97674a77a9ada2b25ce6dd4b6ebbd583/vip-helpers/vip-utils.php#L1381-L1424.

Worth noting that even with this update, the plugin loader still can't correctly load the Disqus plugin, which was one that has been causing us difficulty: https://l.alley.dev/636711d9c8. The reason is that the Disqus plugin doesn't explicitly globalize the variable in question, but tries to reference it later in the plugin entry file with the `global` keyword in function scope, the result being that we don't have any opportunity to actually globalize the variable before the `global` keyword is used.